### PR TITLE
fix: issue with preserving new line characters in read-rule

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,20 @@
 {
-  "ignore": [
-    "__mocks__",
-    "__tests__",
-    "__test_support__",
-    "/coverage"
+  ignore: [
+    '__mocks__',
+    '__tests__',
+    '__test_support__',
+    '/coverage',
   ],
-  "presets": [
-    ["env", {
-      "targets": {
-        "node": 6
-      }
-    }]
+  presets: [
+    ['env', {
+      targets: {
+        node: 6,
+      },
+    }],
   ],
-  "env": {
-    "test": {
-      "ignore": null
+  env: {
+    test: {
+      ignore: null
     }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,20 @@
 {
-  ignore: [
-    '__mocks__',
-    '__tests__',
-    '__test_support__',
-    '/coverage',
+  "ignore": [
+    "__mocks__",
+    "__tests__",
+    "__test_support__",
+    "/coverage"
   ],
-  presets: [
-    ['env', {
-      targets: {
-        node: 6,
-      },
-    }],
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": 6
+      }
+    }]
   ],
-  env: {
-    test: {
-      ignore: null
+  "env": {
+    "test": {
+      "ignore": null
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 lib
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 # If `lib` is ignored, then npm won’t publish it.
 coverage
 __tests__
+__mocks__

--- a/src/actions/__tests__/read-rule.test.js
+++ b/src/actions/__tests__/read-rule.test.js
@@ -76,34 +76,34 @@ describe('readRule()', () => {
     ).toMatchSnapshot()
   })
 
-  it('mixed windows and unix newlines', () => {
+  it('properly handles mixed Windows and Unix newlines', () => {
     const docs = `${heading}\nSome random test:\r\n\r\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(docs)
   })
 
-  it('whitespaces before heading', () => {
+  it('properly handles multiple newlines before heading', () => {
     const docs = `\n\n\n\n\r\n${heading}\n`
     const outputDocs = `${heading}\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
-  it('non string text before heading', () => {
+  it('properly handles non heading text with new line', () => {
     const docs = `\nTest\n`
     const outputDocs = `${heading}\n\nTest\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
-  it('non string text before heading without new line', () => {
+  it('properly handles non heading text without new line', () => {
     const docs = `Test\n`
     const outputDocs = `${heading}\nTest\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
-  it('single line heading', () => {
+  it('properly handles an single line heading', () => {
     const docs = `# Test`
     const outputDocs = `${heading}`
 

--- a/src/actions/__tests__/read-rule.test.js
+++ b/src/actions/__tests__/read-rule.test.js
@@ -9,9 +9,10 @@ const readRule = require('../../actions/read-rule')
 
 const description = 'Require that the file be empty'
 const name = 'require-empty'
+const heading = `# ${description} (${name})`
 const docs =
   `
-# ${description} (${name})
+${heading}
 
 This rule ensures great productivity by requiring that
 all files you write are completely empty.
@@ -76,42 +77,42 @@ describe('readRule()', () => {
   })
 
   it('mixed windows and unix newlines', () => {
-    const docs = `# ${description} (${name})\nSome random test:\r\n\r\n`
+    const docs = `${heading}\nSome random test:\r\n\r\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(docs)
   })
 
   it('whitespaces before heading', () => {
-    const docs = `\n\n\n\n\r\n# ${description} (${name})\n`
-    const outputDocs = `# ${description} (${name})\n`
+    const docs = `\n\n\n\n\r\n${heading}\n`
+    const outputDocs = `${heading}\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
   it('non string text before heading', () => {
     const docs = `\nTest\n`
-    const outputDocs = `# ${description} (${name})\n\nTest\n`
+    const outputDocs = `${heading}\n\nTest\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
   it('non string text before heading without new line', () => {
     const docs = `Test\n`
-    const outputDocs = `# ${description} (${name})\nTest\n`
+    const outputDocs = `${heading}\nTest\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
   it('single line heading', () => {
     const docs = `# Test`
-    const outputDocs = `# ${description} (${name})`
+    const outputDocs = `${heading}`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })
 
-  it('empty file', () => {
+  it('handles an empty file properly', () => {
     const docs = ``
-    const outputDocs = `# ${description} (${name})\n`
+    const outputDocs = `${heading}\n`
 
     expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
   })

--- a/src/actions/__tests__/read-rule.test.js
+++ b/src/actions/__tests__/read-rule.test.js
@@ -74,4 +74,45 @@ describe('readRule()', () => {
       runReadRule(undefined, docs.replace('\n', '\r\n')).newDocs
     ).toMatchSnapshot()
   })
+
+  it('mixed windows and unix newlines', () => {
+    const docs = `# ${description} (${name})\nSome random test:\r\n\r\n`
+
+    expect(runReadRule(undefined, docs).newDocs).toBe(docs)
+  })
+
+  it('whitespaces before heading', () => {
+    const docs = `\n\n\n\n\r\n# ${description} (${name})\n`
+    const outputDocs = `# ${description} (${name})\n`
+
+    expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
+  })
+
+  it('non string text before heading', () => {
+    const docs = `\nTest\n`
+    const outputDocs = `# ${description} (${name})\n\nTest\n`
+
+    expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
+  })
+
+  it('non string text before heading without new line', () => {
+    const docs = `Test\n`
+    const outputDocs = `# ${description} (${name})\nTest\n`
+
+    expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
+  })
+
+  it('single line heading', () => {
+    const docs = `# Test`
+    const outputDocs = `# ${description} (${name})`
+
+    expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
+  })
+
+  it('empty file', () => {
+    const docs = ``
+    const outputDocs = `# ${description} (${name})\n`
+
+    expect(runReadRule(undefined, docs).newDocs).toBe(outputDocs)
+  })
 })

--- a/src/actions/read-rule.js
+++ b/src/actions/read-rule.js
@@ -15,11 +15,13 @@ module.exports = ({ rule, docs, friendlyDocPath }, name) => {
   const fixable = rule.meta.fixable
   const { description, extraDescription, recommended } = rule.meta.docs
 
-  const nl = detectNewline(docs)
+  const heading = `# ${description} (${name})`
 
-  const newDocs = [`# ${description} (${name})`]
-    .concat(docs.split(nl).slice(1))
-    .join(nl)
+  const regTest = /^\s*#[^\r\n]*(\r?\n)?/
+
+  const newDocs = regTest.test(docs)
+    ? docs.replace(regTest, heading + `$1`)
+    : `${heading}${detectNewline(docs)}${docs}`
 
   if (newDocs !== docs) {
     const patch = diff(friendlyDocPath, 'generated', docs, newDocs)

--- a/src/actions/read-rule.js
+++ b/src/actions/read-rule.js
@@ -17,10 +17,10 @@ module.exports = ({ rule, docs, friendlyDocPath }, name) => {
 
   const heading = `# ${description} (${name})`
 
-  const regTest = /^\s*#[^\r\n]*(\r?\n)?/
+  const headingRe = /^\s*#[^\r\n]*(\r?\n)?/
 
-  const newDocs = regTest.test(docs)
-    ? docs.replace(regTest, heading + `$1`)
+  const newDocs = headingRe.test(docs)
+    ? docs.replace(headingRe, heading + `$1`)
     : `${heading}${detectNewline(docs)}${docs}`
 
   if (newDocs !== docs) {


### PR DESCRIPTION

fixes: https://github.com/bradzacher/eslint-plugin-typescript/issues/249
