### PR TITLE
fix: allow to use scoped package names in same way as they are handled in eslint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,68 +1,87 @@
 # v0.3.x
 
 ## v0.3.1
+
 Less output in CI (for real this time)
 
 ## v0.3.0
+
 Convert the codebase to TypeScript; extract the diff function to [a separate package](https://npmjs.com/package/cli-diff)
 
 # v0.2.x
 
 ## v0.2.7
+
 Less output in CI
 
 ## v0.2.6
+
 Tell [Prettier](https://prettier.io) to ignore the table in the README
 
 ## v0.2.5
+
 ## v0.2.4
-*not published due to error*
+
+_not published due to error_
 
 ## v0.2.3
+
 🐛 Fix table output
 
 ## v0.2.2
+
 ## v0.2.1
-*not published due to error*
+
+_not published due to error_
 
 ## v0.2.0
 
-* Update style in README to be a table (**breaking**)
-* Upgrade dependencies
+- Update style in README to be a table (**breaking**)
+- Upgrade dependencies
 
 # v0.1.x
 
 ## v0.1.3
+
 🐛 install `regenerator-runtime` for `async function` support
 
 ## v0.1.2 (💀)
-* Use the documentation file’s predominant newline style when inserting newlines ([#7])
-* Remove `babel-polyfill` and fix the tests on Node v4
+
+- Use the documentation file’s predominant newline style when inserting newlines ([#7])
+- Remove `babel-polyfill` and fix the tests on Node v4
 
 [#7]: https://github.com/j-f1/eslint-docs/issues/7
 
 ## v0.1.1
+
 Properly support the CLI on older versions of Node
 
 ## v0.1.0
+
 Add Babel to enable support for older Node versions.
 
 # v0.0.6
+
 Allow specifying an `Array` for the `extraDescription` key;
 it will be `.join(', ')`ed before being added to the README.
 
 # v0.0.5
+
 ✨ Add support for an `extraDescription` key in the rule metadata
 specifying content that should go in () after the rule description in the README.
 
 # v0.0.4
+
 ✨ prefix the rule names with `PLUGINNAME/` in the README
 
 # v0.0.3
+
 🐛 unwrap Promise properly
 
 # v0.0.2
+
 Actually publish the source code
 
 # v0.0.1
+
 Initial release 🚀

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,19 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ In a Node.js script
 ```js
 const eslintDocs = require('eslint-docs')
 
-eslintDocs(yourProjectDirectory).then(() => {
-  // Everything went OK!
-}, () => {
-  // Something went wrong!
-  // Currently, you’ll have to ask the user to look at the terminal. sorry :(
-})
-
+eslintDocs(yourProjectDirectory).then(
+  () => {
+    // Everything went OK!
+  },
+  () => {
+    // Something went wrong!
+    // Currently, you’ll have to ask the user to look at the terminal. sorry :(
+  }
+)
 ```
 
 `yourProjectDirectory` defaults to the closest directory above `process.cwd()`

--- a/src/package-name.test.ts
+++ b/src/package-name.test.ts
@@ -1,0 +1,29 @@
+import { getShorthandName } from './package-name'
+
+describe('getShorthandName', () => {
+  const testName = (name: string) => getShorthandName(name, 'eslint-plugin')
+
+  it('expect correct package name', () => {
+    expect(testName('')).toEqual('')
+    expect(testName('foo-test')).toEqual('foo-test')
+    expect(testName('eslint-plugin-eslint-plugin')).toEqual('eslint-plugin')
+    expect(testName('eslint-plugin-vue')).toEqual('vue')
+    expect(testName('eslint-plugin-typescript')).toEqual('typescript')
+    expect(testName('eslint-plugin-jest')).toEqual('jest')
+  })
+
+  it('expect correct scoped package name', () => {
+    expect(testName('@test/foo-test')).toEqual('@test/foo-test')
+    expect(testName('@test/eslint-plugin-eslint-plugin')).toEqual(
+      '@test/eslint-plugin'
+    )
+    expect(testName('@test/eslint-plugin-vue')).toEqual('@test/vue')
+    expect(testName('@test/eslint-plugin-typescript')).toEqual(
+      '@test/typescript'
+    )
+    expect(testName('@test/eslint-plugin')).toEqual('@test')
+    expect(testName('@typescript-eslint/eslint-plugin')).toEqual(
+      '@typescript-eslint'
+    )
+  })
+})

--- a/src/package-name.test.ts
+++ b/src/package-name.test.ts
@@ -3,7 +3,7 @@ import { getShorthandName } from './package-name'
 describe('getShorthandName', () => {
   const testName = (name: string) => getShorthandName(name, 'eslint-plugin')
 
-  it('expect correct package name', () => {
+  it('properly shortens non-scoped package names', () => {
     expect(testName('')).toEqual('')
     expect(testName('foo-test')).toEqual('foo-test')
     expect(testName('eslint-plugin-eslint-plugin')).toEqual('eslint-plugin')
@@ -12,7 +12,7 @@ describe('getShorthandName', () => {
     expect(testName('eslint-plugin-jest')).toEqual('jest')
   })
 
-  it('expect correct scoped package name', () => {
+  it('properly shortens scoped package names', () => {
     expect(testName('@test/foo-test')).toEqual('@test/foo-test')
     expect(testName('@test/eslint-plugin-eslint-plugin')).toEqual(
       '@test/eslint-plugin'

--- a/src/package-name.ts
+++ b/src/package-name.ts
@@ -22,10 +22,10 @@
 
 /**
  * Removes the prefix from a fullname.
- * @param {string} fullname The term which may have the prefix.
- * @param {string} prefix The prefix to remove.
- * @returns {string} The term without prefix.
- * @see https://github.com/eslint/eslint/blob/6009239042cb651bc7ca6b8c81bbe44c40327430/lib/util/naming.js#L69
+ * Source: https://github.com/eslint/eslint/blob/60092390/lib/util/naming.js#L69
+ * @param fullname The term which may have the prefix.
+ * @param prefix The prefix to remove.
+ * @returns The term without prefix.
  */
 export function getShorthandName(fullname: string, prefix: string) {
   if (fullname[0] === '@') {

--- a/src/package-name.ts
+++ b/src/package-name.ts
@@ -1,0 +1,47 @@
+/**
+ Copyright JS Foundation and other contributors, https://js.foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+/**
+ * Removes the prefix from a fullname.
+ * @param {string} fullname The term which may have the prefix.
+ * @param {string} prefix The prefix to remove.
+ * @returns {string} The term without prefix.
+ * @see https://github.com/eslint/eslint/blob/6009239042cb651bc7ca6b8c81bbe44c40327430/lib/util/naming.js#L69
+ */
+export function getShorthandName(fullname: string, prefix: string) {
+  if (fullname[0] === '@') {
+    let matchResult = new RegExp(`^(@[^/]+)/${prefix}$`).exec(fullname)
+
+    if (matchResult) {
+      return matchResult[1]
+    }
+
+    matchResult = new RegExp(`^(@[^/]+)/${prefix}-(.+)$`).exec(fullname)
+    if (matchResult) {
+      return `${matchResult[1]}/${matchResult[2]}`
+    }
+  } else if (fullname.startsWith(`${prefix}-`)) {
+    return fullname.slice(prefix.length + 1)
+  }
+
+  return fullname
+}

--- a/src/package-name.ts
+++ b/src/package-name.ts
@@ -22,7 +22,7 @@
 
 /**
  * Removes the prefix from a fullname.
- * Source: https://github.com/eslint/eslint/blob/60092390/lib/util/naming.js#L69
+ * @see https://github.com/eslint/eslint/blob/60092390/lib/util/naming.js#L69
  * @param fullname The term which may have the prefix.
  * @param prefix The prefix to remove.
  * @returns The term without prefix.

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,4 +1,5 @@
 import { join } from 'path'
+import { getShorthandName } from './package-name'
 
 export interface Paths {
   rulesDir: string
@@ -13,9 +14,9 @@ export const handlers: Handlers = {
   docsDir: projectRoot => join(projectRoot, 'docs', 'rules'),
   readmePath: projectRoot => join(projectRoot, 'README.md'),
   pluginName: projectRoot =>
-    require(join(projectRoot, 'package.json')).name.replace(
-      /^eslint-plugin-/,
-      ''
+    getShorthandName(
+      require(join(projectRoot, 'package.json')).name,
+      'eslint-plugin'
     ),
 }
 


### PR DESCRIPTION
this PR contains function extracted from eslint: https://github.com/eslint/eslint/blob/6009239042cb651bc7ca6b8c81bbe44c40327430/lib/util/naming.js#L69

its best if its going to use same logic to generate package name as eslint to limit potential issues with other packages

fixes: #38 